### PR TITLE
Modify showing icons based on organization provider

### DIFF
--- a/resources/lang/ar/gitscrum.php
+++ b/resources/lang/ar/gitscrum.php
@@ -116,7 +116,9 @@ return array (
   'edit' => 'تعديل',
   'delete' => 'حذف',
   'open' => 'مفتوحة',
-  'go-to-gitHub' => 'إذهب إلى GitHub',
+  'go-to-github' => 'إذهب إلى GitHub',
+  'go-to-bitbucket' => 'إذهب إلى BitBucket',
+  'go-to-gitlab' => 'إذهب إلى GitLab',
   'edit-issue' => 'تعديل المسئله',
   'this-issue-is-in-a
         sprint-that-is' => 'هذة المسئله فى سبرنت',

--- a/resources/lang/en/gitscrum.php
+++ b/resources/lang/en/gitscrum.php
@@ -116,7 +116,9 @@ return array (
   'edit' => 'Edit',
   'delete' => 'Delete',
   'open' => 'Open',
-  'go-to-gitHub' => 'Go to GitHub',
+  'go-to-github' => 'Go to GitHub',
+  'go-to-bitbucket' => 'Go to BitBucket',
+  'go-to-gitlab'=> 'Go to GitLab',
   'edit-issue' => 'Edit Issue',
   'this-issue-is-in-a
         sprint-that-is' => 'This issue is in a sprint that is',

--- a/resources/views/partials/lists/product-backlogs.blade.php
+++ b/resources/views/partials/lists/product-backlogs.blade.php
@@ -20,8 +20,8 @@
     <td><span class="text-middle">{{$list->organization->title}}</span></td>
     <td class="text-right" width="60">
         <a href="{{$list->html_url}}" target="_blank" class="text-middle icon-github"
-            data-toggle="tooltip" data-placement="left"
-            title="{{trans('gitscrum.go-to-gitHub')}}" alt="{{trans('gitscrum.go-to-gitHub')}}">
-            <i class="fa fa-github" aria-hidden="true"></i></a>
+           data-toggle="tooltip" data-placement="left"
+           title="{{trans('gitscrum.go-to-'.$list->organization->provider)}}" alt="{{trans('gitscrum.go-to-'.$list->organization->provider)}}">
+            <i class="fa fa-{{$list->organization->provider}}" aria-hidden="true"></i></a>
     </td>
 </tr>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

this **PR** fixes the icons to be rendered dynamically based on the provider in #229 

## Screenshots (if appropriate)

![gitscrum](https://user-images.githubusercontent.com/17250137/35151102-a1bf1eb0-fd25-11e7-94b1-102faff7e798.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [ ] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
