### PR TITLE
pagination on backlog + incorrect groupBy on sprint planning view

### DIFF
--- a/app/Http/Controllers/Web/IssueController.php
+++ b/app/Http/Controllers/Web/IssueController.php
@@ -25,7 +25,7 @@ class IssueController extends Controller
 
         return view('issues.index')
             ->with('sprint', $sprint)
-            ->with('issues', $issues->sortBy('position')->groupBy('config_issue_effort_id'))
+            ->with('issues', $issues->sortBy('position')->groupBy('config_status_id'))
             ->with('configStatus', ConfigStatus::type('issues')->get());
     }
 

--- a/app/Http/Controllers/Web/ProductBacklogController.php
+++ b/app/Http/Controllers/Web/ProductBacklogController.php
@@ -16,7 +16,7 @@ class ProductBacklogController extends Controller
      */
     public function index(Request $request, $mode = 'default')
     {
-        $backlogs = ProductBacklog::paginate($request->page);
+        $backlogs = ProductBacklog::paginate(env('APP_PAGINATE'));
         return view('product_backlogs.index-'.$mode)
             ->with('backlogs', $backlogs);
     }


### PR DESCRIPTION
weird behavior of pagination when number of backlog > 20 
incorrect groupBy on sprint planning view

## Description

The paginate function take on argument the number of displayed items and not the page number
Also the issue on the spring planning are not grouped by the correct parameters

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [ ] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
